### PR TITLE
Update babble.css

### DIFF
--- a/assets/stylesheets/babble.css
+++ b/assets/stylesheets/babble.css
@@ -42,6 +42,7 @@
 
 li.babble-post .babble-post-content a.mention {
   display: inline;
+  padding: 0;
 }
 
 .babble-post-avatar img {


### PR DESCRIPTION
Mentions in chat messages overlap with the previous line due to the 5px padding