### PR TITLE
Don't show unread count when dropdown is visible or babble icon is not visible

### DIFF
--- a/assets/javascripts/discourse/components/babble-icon.js.es6
+++ b/assets/javascripts/discourse/components/babble-icon.js.es6
@@ -3,10 +3,16 @@ export default Ember.Component.extend({
   tagName: 'li',
   topicVersion: 0,
 
+  icon: Ember.computed(function() { return $(this.element).find(".babble-icon"); }),
   topic: Ember.computed('topicVersion', function() { return Discourse.Babble && Discourse.Babble.topic }),
+  
   unreadCount: Ember.computed('topicVersion', function() {
     var topic = this.get('topic')
-    if (!topic) { return 0 }
+    var icon = this.get("icon")
+    // icon is active or invisible, so no need to show unread count
+    if (!topic || icon.is(".active, :not(:visible)")) { 
+        return 0 
+    }
     return topic.highest_post_number - topic.last_read_post_number
   }),
 


### PR DESCRIPTION
Fix for #4, the idea is to just not show unread count, when dropdown is visible.