### PR TITLE
placeholder+i18n support, addresses #9 and #10

### DIFF
--- a/assets/javascripts/discourse/components/babble-composer.js.es6
+++ b/assets/javascripts/discourse/components/babble-composer.js.es6
@@ -23,6 +23,10 @@ export default Ember.Component.extend(Presence, {
     if (this.get('textValidation.failed')) return true;
   }.property('textValidation'),
 
+  i18nPlaceholder: function() {
+    return I18n.t("babble.placeholder");
+  }.property('name_key'),
+
   actions: {
     submit: function(context) {
       var self = context || this;

--- a/assets/javascripts/discourse/templates/components/babble-composer.hbs
+++ b/assets/javascripts/discourse/templates/components/babble-composer.hbs
@@ -1,4 +1,4 @@
 <div class="babble-composer">
-  {{textarea value=text}}
-  <button {{action 'submit'}} {{bind-attr disabled="submitDisabled"}} class="btn btn-primary pull-right">Send</button>
+  {{textarea value=text placeholder=i18nPlaceholder }}
+  <button {{action 'submit'}} {{bind-attr disabled="submitDisabled"}} class="btn btn-primary pull-right">{{i18n 'babble.send'}}</button>
 </div>

--- a/assets/javascripts/discourse/templates/components/babble-composer.hbs
+++ b/assets/javascripts/discourse/templates/components/babble-composer.hbs
@@ -1,4 +1,4 @@
 <div class="babble-composer">
-  {{textarea value=text placeholder=i18nPlaceholder }}
+  {{textarea value=text placeholder="{{i18n 'babble.placeholder'}}" }}
   <button {{action 'submit'}} {{bind-attr disabled="submitDisabled"}} class="btn btn-primary pull-right">{{i18n 'babble.send'}}</button>
 </div>

--- a/config/locales/client.de.yml
+++ b/config/locales/client.de.yml
@@ -1,0 +1,6 @@
+de:
+  js:
+    babble:
+      placeholder: "Chat-Nachricht hier eingeben..."
+      send: "Abschicken"
+      title: "Shoutbox!"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,0 +1,6 @@
+en:
+  js:
+    babble:
+      placeholder: "type your chat message here..."
+      send: "Send"
+      title: "Shoutbox!"


### PR DESCRIPTION
added some localizations for the submit button, the composer placeholder and the tooltip for the bullhorn icon. Languages: English+German