### PR TITLE
Handle Discourse change 'Remove Presence' mixin

### DIFF
--- a/assets/javascripts/discourse/components/babble-composer.js.es6
+++ b/assets/javascripts/discourse/components/babble-composer.js.es6
@@ -1,6 +1,5 @@
-import Presence from 'discourse/mixins/presence';
 
-export default Ember.Component.extend(Presence, {
+export default Ember.Component.extend({
   classNames: ['babble-post-composer'],
 
   _init: function() {
@@ -16,7 +15,7 @@ export default Ember.Component.extend(Presence, {
 
   textValidation: function() {
     var validation = { ok: true };
-    if (this.blank('text')) {
+    if (Ember.isEmpty(this.get('text')))
       var validation = { failed: true };
     }
 


### PR DESCRIPTION
Eviltrout has commited this: https://github.com/discourse/discourse/commit/02a968bd27c32a7413fdb63f696abfcecd6e018e
...which removed the Presence mixin, rendering "this.blank" unusable. Substitute with Ember.isEmpty and remove the import line, and we're good to go. Addresses https://github.com/gdpelican/babble/issues/21