### PR TITLE
Move notification badge to the left

### DIFF
--- a/assets/javascripts/discourse/templates/components/babble-icon.hbs
+++ b/assets/javascripts/discourse/templates/components/babble-icon.hbs
@@ -7,6 +7,6 @@
        {{fa-icon "bullhorn" label="babble.title"}}
     </a>
     {{#if unreadCount}}
-      <a href class='badge-notification unread-notifications'>{{unreadCount}}</a>
+      <a href class='badge-notification unread-notifications' style='right: auto; left: -4px;'>{{unreadCount}}</a>
     {{/if}}
   {{/unless}}


### PR DESCRIPTION
Fix for https://github.com/gdpelican/babble/issues/25