### PR TITLE
notification badges go to the left

### DIFF
--- a/assets/javascripts/discourse/templates/components/babble-icon.hbs
+++ b/assets/javascripts/discourse/templates/components/babble-icon.hbs
@@ -7,6 +7,6 @@
        {{fa-icon "bullhorn" label="babble.title"}}
     </a>
     {{#if unreadCount}}
-      <a href class='badge-notification unread-notifications'>{{unreadCount}}</a>
+      <a href class='badge-notification unread-notifications babble-notifications-left'>{{unreadCount}}</a>
     {{/if}}
   {{/unless}}

--- a/assets/javascripts/discourse/templates/components/babble-icon.hbs
+++ b/assets/javascripts/discourse/templates/components/babble-icon.hbs
@@ -7,6 +7,6 @@
        {{fa-icon "bullhorn" label="babble.title"}}
     </a>
     {{#if unreadCount}}
-      <a href class='badge-notification unread-notifications babble-notifications-left'>{{unreadCount}}</a>
+      <a href class='badge-notification unread-notifications babble-unread-notification'>{{unreadCount}}</a>
     {{/if}}
   {{/unless}}

--- a/assets/javascripts/discourse/templates/components/babble-icon.hbs
+++ b/assets/javascripts/discourse/templates/components/babble-icon.hbs
@@ -7,6 +7,6 @@
        {{fa-icon "bullhorn" label="babble.title"}}
     </a>
     {{#if unreadCount}}
-      <a href class='badge-notification unread-notifications babble-unread-notification'>{{unreadCount}}</a>
+      <a href class='badge-notification unread-notifications babble-unread-notifications'>{{unreadCount}}</a>
     {{/if}}
   {{/unless}}

--- a/assets/stylesheets/babble.css
+++ b/assets/stylesheets/babble.css
@@ -84,3 +84,9 @@ li.babble-post .babble-post-content a.mention {
   padding: 5px;
   margin: 0;
 }
+
+a.babble-notifications-left {
+  right: auto !important; /* I know. But I'd like to base this on the Discourse style and have to
+                             make this style stick. Therefore: I'm sorry. */
+  left: -4px;
+}

--- a/assets/stylesheets/babble.css
+++ b/assets/stylesheets/babble.css
@@ -85,8 +85,7 @@ li.babble-post .babble-post-content a.mention {
   margin: 0;
 }
 
-a.babble-notifications-left {
-  right: auto !important; /* I know. But I'd like to base this on the Discourse style and have to
-                             make this style stick. Therefore: I'm sorry. */
+.d-header .icons .unread-notifications.babble-unread-notifications {
+  right: auto;
   left: -4px;
 }


### PR DESCRIPTION
…of the babble icon.

This time: CSS class style!

Re: https://github.com/gdpelican/babble/issues/25