### PR TITLE
Add emoji picker to composer text area

### DIFF
--- a/assets/javascripts/discourse/components/babble-composer.js.es6
+++ b/assets/javascripts/discourse/components/babble-composer.js.es6
@@ -31,7 +31,19 @@ export default Ember.Component.extend({
   }.property('textValidation'),
 
   actions: {
-    selectEmoji: showSelector,
+    selectEmoji: function() {
+      var self = this
+      showSelector()
+      $('.emoji-page a').off('click').on('click', function() {
+        var title = $(this).attr('title')
+        self.set('text', (self.get('text') || '').trimRight() + ' :' + title + ':')
+
+        $('.emoji-modal, .emoji-modal-wrapper').remove()
+        $('body, textarea').off('keydown.emoji')
+        $('.babble-post-composer textarea').focus()
+        return false
+      })
+    },
 
     submit: function(context) {
       var self = context || this;

--- a/assets/javascripts/discourse/templates/components/babble-composer.hbs
+++ b/assets/javascripts/discourse/templates/components/babble-composer.hbs
@@ -3,6 +3,7 @@
     {{textarea value=text placeholder=placeholder }}
   </div>
   <button {{action 'submit'}} {{bind-attr disabled="submitDisabled"}} class="btn btn-primary pull-right">{{i18n 'babble.send'}}</button>
+  <button {{action 'selectEmoji'}} class="wmd-button wmd-emoji-button" title="Emoji :smile:" aria-label="Emoji :smile:"></button>
   {{#if showError}}
     <span class="babble-composer-error-message">{{i18n 'babble.error_message'}}</span>
   {{/if}}

--- a/assets/stylesheets/babble.scss
+++ b/assets/stylesheets/babble.scss
@@ -11,7 +11,7 @@
 .babble-empty-topic-message {
   color: #ccc;
   text-align: center;
-  padding-top: 25%;
+  padding: 25% 0;
 }
 
 .babble-post .babble-post-avatar a,
@@ -95,6 +95,13 @@ li.babble-post .babble-post-content a.mention {
   padding: 5px;
   margin: 0;
   resize: none;
+}
+
+.babble-post-composer button.wmd-emoji-button {
+  position: absolute;
+  top: 2px;
+  right: -2px;
+  color: #888;
 }
 
 .babble-post .babble-post-body .cooked img {


### PR DESCRIPTION
Thing that still sucks: exiting out of the composer will close the babble chat menu as well.