### PR TITLE
duplicate babble_max_topic_size

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -19,6 +19,3 @@ plugins:
   babble_username:
     default: chattykathy
     hidden: true
-  babble_max_topic_size:
-    default: 200
-    hidden: true


### PR DESCRIPTION
Lines 22-24 were duplicating lines 11+12, but making this setting hidden. Since you've also added a UI text for this item, I guess this is an oversight... ;)