### PR TITLE
prevent long words from creating horizontal scrollbars

### DIFF
--- a/assets/javascripts/discourse/components/babble-composer.js.es6
+++ b/assets/javascripts/discourse/components/babble-composer.js.es6
@@ -33,12 +33,13 @@ export default Ember.Component.extend({
   actions: {
     selectEmoji: function() {
       var self = this
-      showSelector()
-      $('.emoji-page a').off('click').on('click', function() {
+      var c = showModal('smileypicker')      
+      c.setProperties({ composerView: self })
+      $('.smileypicker-box img').on('click', function() {
         var title = $(this).attr('title')
         self.set('text', (self.get('text') || '').trimRight() + ' :' + title + ':')
 
-        $('.emoji-modal, .emoji-modal-wrapper').remove()
+        $('.modal, .modal-outer-container').remove()
         $('body, textarea').off('keydown.emoji')
         $('.babble-post-composer textarea').focus()
         return false

--- a/assets/stylesheets/babble.scss
+++ b/assets/stylesheets/babble.scss
@@ -33,6 +33,7 @@
   list-style-type: none;
   clear: both;
   word-break: break-all;
+  word-break: break-word; /* Webkit fix */
 }
 
 .babble-post:hover {

--- a/assets/stylesheets/babble.scss
+++ b/assets/stylesheets/babble.scss
@@ -32,6 +32,7 @@
   position: relative;
   list-style-type: none;
   clear: both;
+  word-break: break-all;
 }
 
 .babble-post:hover {


### PR DESCRIPTION
…by introducing a word-break CSS rule for the posts. Does of course not
affect standard situations where there’s enough white space in a line
to break it there.

Sry, this is a minor thing I could use if somebody types a very_nasty_super_long_word_in_the_message_box_which_will_break_things_for_every_one… and such stuff happens in production environments. ;)