### PR TITLE
Refer to 'everyone' group by ID instead of name (name can be localized)

### DIFF
--- a/assets/javascripts/discourse/routes/admin-chat.js.es6
+++ b/assets/javascripts/discourse/routes/admin-chat.js.es6
@@ -17,13 +17,15 @@ export default Discourse.Route.extend({
     const self = this
 
     var setup = function(selected, available) {
+      const everyoneGroupId = 0;
+
       if (selected) { self._selected = selected }
       if (available) { self._available = available }
       if (!self._available || !self._selected) { return }
 
       self._available = _.map(self._available, function(g) { g.automatic = false; return g })
       self._selected  = _.map(self._selected,  function(g) { g.automatic = false; return g })
-      self._available = _.reject(self._available, function(g) { return g.name == 'everyone'; })
+      self._available = _.reject(self._available, function(g) { return g.id == everyoneGroupId; })
 
       model.allowed_group_ids = _.pluck(self._selected, 'id')
       controller.setProperties({ model: model, available: self._available, selected: self._selected })


### PR DESCRIPTION
Hi,

I understand the `everyone` group should not be used in Babble channel permissions, and `trust_level_0` (the default) should be used instead. We run Discourse in Finnish and it has localized the name of the group so that it's `kaikki`, not `everyone`. As a result, that group is offered as an option in the drop-down for the *Visible to* field (and, naturally enough, it is the most obvious-looking option for public channels).

Here's a patch that refers to the `everyone` group via group ID zero instead of the group name. I did a quick test and it seems to work in Finnish Discourse. I hope group ID zero is stable but I'm not absolutely sure of that. Since it's a pre-made group and is the superset of all other groups, you'd think it's a reasonble bet that the ID will always be zero.

BR,
Lassi