### PR TITLE
Closing emoji box should make chat box closeable

### DIFF
--- a/assets/javascripts/discourse/components/babble-composer.js.es6
+++ b/assets/javascripts/discourse/components/babble-composer.js.es6
@@ -81,9 +81,6 @@ export default Ember.Component.extend({
       }) // sorry mom.
 
       $('html').off('click.close-menu-panel')
-      $('.emoji-modal-wrapper').on('click', function() {
-        $('html').on('click.close-menu-panel', closeMenuPanelHandler.handler)
-      })
 
       showSelector({
         container: this.container,
@@ -95,6 +92,13 @@ export default Ember.Component.extend({
           $('html').on('click.close-menu-panel', closeMenuPanelHandler.handler)
           return false
         }
+      })
+
+      $('.emoji-modal-wrapper').on('click', function(event) {
+        $('html').on('click.close-menu-panel', closeMenuPanelHandler.handler)
+        // The click responsible for closing emoji box doesn't count
+        // as a click to close chat box.
+        event.stopPropagation()
       })
     },
 


### PR DESCRIPTION
Before this change, changing emoji box by clicking outside of it made chat box uncloseable by pressing outside of it. This was caused by .emoji-modal-wrapper not existing at the point where event was set.