### PR TITLE
Add remote POST option to post JSON

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -7,3 +7,5 @@ en:
     babble_placeholder: "Leave blank for default placeholder text in empty chat textarea. Or enter your custom text here."
     babble_icon: "Font Awesome code (fa- omitted) for the Babble icon in the upper right corner. See http://fontawesome.io/cheatsheet/ for a list of icons."
     babble_category_name: "Discourse category for Babble topics."
+    babble_remote_post: "Enable remote POST on message."
+    babble_remote_url: "POST URL"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,3 +12,7 @@ plugins:
     default: 200
   babble_category_name:
     default: chat
+  babble_remote_post:
+    default: false
+  babble_remote_url:
+    default: http://example.com/api/message/add

--- a/plugin.rb
+++ b/plugin.rb
@@ -94,10 +94,17 @@ after_initialize do
       perform_fetch do
         @post = Babble::PostCreator.create(current_user, post_creator_params)
         if @post.persisted?
+          success_callback
           respond_with @post, serializer: Babble::PostSerializer
         else
           respond_with_unprocessable
         end
+      end
+    end
+
+    def success_callback
+      if (SiteSetting.babble_remote_post)
+        response = RestClient.post(SiteSetting.babble_remote_url, { current_user: current_user.username, message: @post.cooked }) unless params[:from_discord]
       end
     end
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -104,7 +104,7 @@ after_initialize do
 
     def success_callback
       if (SiteSetting.babble_remote_post)
-        response = RestClient.post(SiteSetting.babble_remote_url, { current_user: current_user.username, message: @post.cooked }) unless params[:from_discord]
+        RestClient.post(SiteSetting.babble_remote_url, { current_user: current_user.username, message: @post.cooked }) unless params[:skip_callback]
       end
     end
 


### PR DESCRIPTION
This adds an option to POST JSON in the following format, to a configurable URL.

```
{"current_user":"username","message",@post.cooked}
```