### PR TITLE
Fix iOS scrolling issue

### DIFF
--- a/assets/stylesheets/babble.scss
+++ b/assets/stylesheets/babble.scss
@@ -415,7 +415,7 @@ li.babble-post .babble-post-content a.mention {
 
   .slide-in { // styles for slide-in menu
     box-sizing: border-box;
-    height: calc(100vh - 64px) !important;
+    height: calc(100% - 58px) !important;
     @media (max-width: 450px) { width: 100% !important; }
   }
   .babble-chat {
@@ -443,7 +443,8 @@ li.babble-post .babble-post-content a.mention {
     -webkit-flex-shrink: 1;
     -webkit-flex-basis: auto;
     overflow-x: hidden;
-    overflow-y: auto;
+    overflow-y: scroll;
+    -webkit-overflow-scrolling: touch;
     height: 500px;
     margin: 0 7px;
   }


### PR DESCRIPTION
This fixes the lack of momentum scrolling on iOS. Also change the slide-in div
to use percentage for height instead of vh units because safari takes up some of the 
bottom of the screen when you tap near the bottom (it shows a toolbar).

@gdpelican I was not able to test how it looks on a mobile android. Only tested in mobile emulator on chrome and on an iphone.