### PR TITLE
Fixed emoji-picker problem.

### DIFF
--- a/assets/javascripts/discourse/connectors/below-site-header/babble-emoji-picker.hbs
+++ b/assets/javascripts/discourse/connectors/below-site-header/babble-emoji-picker.hbs
@@ -1,4 +1,4 @@
 {{emoji-picker
     emojiSelected='emojiSelected'
     automaticPositioning=false
-isBabble=true}}
+    isBabble=true}}

--- a/assets/javascripts/discourse/connectors/below-site-header/babble-emoji-picker.hbs
+++ b/assets/javascripts/discourse/connectors/below-site-header/babble-emoji-picker.hbs
@@ -1,1 +1,4 @@
-{{emoji-picker emojiSelected='emojiSelected'}}
+{{emoji-picker
+    emojiSelected='emojiSelected'
+    automaticPositioning=false
+isBabble=true}}

--- a/assets/javascripts/discourse/connectors/below-site-header/babble-emoji-picker.js.es6
+++ b/assets/javascripts/discourse/connectors/below-site-header/babble-emoji-picker.js.es6
@@ -2,7 +2,7 @@ export default {
   actions: {
     emojiSelected(code) {
       const textarea = $('.babble-composer-wrapper textarea');
-      textarea.val(textarea.val() + `:${code}:`);
+      textarea.val(textarea.val() + ` :${code}:`);
     }
   }
 }

--- a/assets/javascripts/discourse/initializers/babble-common-init.js.es6
+++ b/assets/javascripts/discourse/initializers/babble-common-init.js.es6
@@ -19,24 +19,23 @@ export default {
       api.modifyClass("component:emoji-picker", {
         @on('didInsertElement')
         addOpenEvent() {
-          this.appEvents.on("emoji-picker:open", () => {
-            this.set("active", true);
-            this.set("forBabble", true);
-          });
+          if (this.get('isBabble')) {
+            this.appEvents.on('babble-emoji-picker:open', () => this.set('active', true));
+          }
         },
 
         @on('willDestroyElement')
         removeOpenEvent() {
-          this.appEvents.off("emoji-picker:open");
+          if (this.get('isBabble')) this.appEvents.off('babble-emoji-picker:open');
         },
-
+ 
         @observes('active')
         triggerAttrUpdate() {
-          this.didUpdateAttrs();
+          this.get("active") === true ? this.show() : this.close();
         },
-
-        _positionPicker(){
-          if (!this.get('forBabble')) return this._super();
+          
+        _positionPicker() {
+          if (!this.get('isBabble')) return this._super();
 
           let windowWidth = this.$(window).width();
 

--- a/assets/javascripts/discourse/initializers/babble-common-init.js.es6
+++ b/assets/javascripts/discourse/initializers/babble-common-init.js.es6
@@ -31,7 +31,7 @@ export default {
  
         @observes('active')
         triggerAttrUpdate() {
-          this.get("active") === true ? this.show() : this.close();
+          this._setState();
         },
           
         _positionPicker() {

--- a/assets/javascripts/discourse/widgets/babble-composer.js.es6
+++ b/assets/javascripts/discourse/widgets/babble-composer.js.es6
@@ -29,7 +29,7 @@ export default createWidget('babble-composer', {
   },
 
   selectEmoji() {
-    this.appEvents.trigger("emoji-picker:open");
+    this.appEvents.trigger("babble-emoji-picker:open");
   },
 
   cancel() {


### PR DESCRIPTION
A few things here:

1) Since the plugin simply modifies the standard emoji-picker class, need to be a bit careful here.  Marking the emoji-picker component with an `isBabble` attribute ensures that the custom code only runs for the Babble emoji-picker.

2) I don't know how to trigger Ember's `didUpdateAttrs` event (which the standard emoji-picker listens to to decide whether to show or hide) when `active` changes.  The old code simply observes on `active` and calls `this.didUpdateAttrs();` which caused the plugin to break when the standard emoji-picker changes to use the `didUpdateAttrs` event instead of the `didUpdateAttrs` function.

3) I fudged it by calling the `_setState` method, which is the function that the standard emoji-picker class uses as a handler for `didUpdateAttrs`.  Needless to say, the plugin will break again when the standard emoji-picker code changes.

4) I also changed the activation event from `emoji-picker:open` to `babble-emoji-picker:open` because there is already a `emoji-picker:close` event in the standard class, so maybe in the future they'll also add `emoji-picker:open` and break the plugin again.

Ultimately, there needs to be a way to manually trigger the `didUpdateAttrs` event when `active` changes (any Ember expert here?) so that the plugin won't be so brittle.

Alternatively, go the way of `retort` and create a new subclass for the standard emoji-picker.  This should solve a huge amount of future problems.
