### PR TITLE
Avoiding initialize the sidebar when user is logged out

### DIFF
--- a/assets/javascripts/discourse/components/babble-sidebar-component.js.es6
+++ b/assets/javascripts/discourse/components/babble-sidebar-component.js.es6
@@ -21,6 +21,7 @@ export default MountWidget.extend({
   @on('didInsertElement')
   _initialize() {
     if (Babble.disabled()) { return }
+    if (Discourse.User.current() === null) { return }
 
     this.set('targetObject', this)
 


### PR DESCRIPTION
The Chat is currently breaking the OAuth flow for at least Google (but potentially all other providers too). The sidebar component does not check for the current user and makes ajax calls to the Rails backend that get interrupted with access denied and subsequently stored as a destination_url cookie that Discourse uses to setup the OAuth flow.

The steps to reproduce the bug are:
1. Enable OAuth with Google
2. Start an incognito session and make sure there’s only Babble installed and no other plugins
3. Login normally (not using Google)
4. Log out
5. Inspect the cookies and look for the destination_url, it should have an URL with topics.json there
6. Now login with Google OAuth
7. During the confirmation page inspect the output of this line: https://github.com/discourse/discourse/blob/master/app/views/users/omniauth_callbacks/complete.html.erb#L28
8. Now complete the flow, and you should be redirected to the topics.json page instead of the regular HTML.

Video with the steps to reproduce here:
https://meta.discourse.org/t/babble-a-chat-plugin/31753/811?u=daniel_lopes

I'm running this fix in Production and it's working fine for me.


