### PR TITLE
Changed babble-icon-unread color

### DIFF
--- a/assets/stylesheets/babble.scss
+++ b/assets/stylesheets/babble.scss
@@ -3,7 +3,7 @@ $default-chat-width: 300px;
 #babble-icon-unread {
   i {
     transition: color ease-in-out 0.5s;
-    color: dark-light-choose(scale-color($primary, $lightness: 50%), scale-color($secondary, $lightness: 50%));
+    color: $danger;
   }
 }
 


### PR DESCRIPTION
Make unread icon great again!

Changed the `#babble-icon-unread i` color to `$danger` so when you have an unread message, the icon will look like this 
![image](https://user-images.githubusercontent.com/10809337/37544050-f9850c6c-2963-11e8-888b-048531b45a16.png)
