### PR TITLE
Make all icons compatible with FontAwesome 5

### DIFF
--- a/assets/javascripts/discourse/widgets/templates/babble-channels.js.es6
+++ b/assets/javascripts/discourse/widgets/templates/babble-channels.js.es6
@@ -1,5 +1,6 @@
 import { h } from 'virtual-dom'
 import { avatarImg } from 'discourse/widgets/post'
+import { iconNode } from "discourse-common/lib/icon-library";
 import Babble from '../../lib/babble'
 
 export default Ember.Object.create({
@@ -47,7 +48,7 @@ export default Ember.Object.create({
 
   topicsHeaderIcon() {
     const icon = Discourse.SiteSettings.babble_icon
-    return h(`i.fa.fa-${icon}.d-icon.d-icon-${icon}.babble-title-icon`)
+    return iconNode(icon, { class: 'babble-title-icon'} )
   },
 
   topicsHeaderText() {

--- a/assets/javascripts/discourse/widgets/templates/babble-post-actions.js.es6
+++ b/assets/javascripts/discourse/widgets/templates/babble-post-actions.js.es6
@@ -1,5 +1,6 @@
 
 import { h } from 'virtual-dom'
+import { iconNode } from "discourse-common/lib/icon-library";
 
 export default Ember.Object.create({
   render(widget) {
@@ -40,7 +41,7 @@ export default Ember.Object.create({
   flag() {
     if (this.post.can_flag) {
       if (this.post.has_flagged) {
-        return h('div.widget-link.babble-link-disabled', [h('i.fa.fa-flag'), I18n.t('babble.flagged')])
+        return h('div.widget-link.disabled.btn', [iconNode('flag'), I18n.t('babble.flagged')])
       } else {
         return this.widget.attach('link', { className: 'btn', icon: 'flag', action: 'flag', label: 'post.actions.flag' })
       }

--- a/assets/javascripts/discourse/widgets/templates/babble-post-actions.js.es6
+++ b/assets/javascripts/discourse/widgets/templates/babble-post-actions.js.es6
@@ -41,7 +41,7 @@ export default Ember.Object.create({
   flag() {
     if (this.post.can_flag) {
       if (this.post.has_flagged) {
-        return h('div.widget-link.disabled.btn', [iconNode('flag'), I18n.t('babble.flagged')])
+        return h('div.widget-link.babble-link-disabled.btn', [iconNode('flag'), I18n.t('babble.flagged')])
       } else {
         return this.widget.attach('link', { className: 'btn', icon: 'flag', action: 'flag', label: 'post.actions.flag' })
       }

--- a/assets/javascripts/discourse/widgets/templates/babble-post.js.es6
+++ b/assets/javascripts/discourse/widgets/templates/babble-post.js.es6
@@ -4,6 +4,7 @@ import RawHtml from 'discourse/widgets/raw-html';
 import { relativeAge } from 'discourse/lib/formatter'
 import { avatarImg } from 'discourse/widgets/post'
 import { emojiUnescape } from 'discourse/lib/text'
+import { iconNode } from "discourse-common/lib/icon-library";
 
 export default Ember.Object.create({
   render(widget) {
@@ -66,7 +67,7 @@ export default Ember.Object.create({
     } else if (this.post.user_id) {
       return avatarImg('medium', {template: this.post.avatar_template, username: this.post.username})
     } else {
-      return h('i.fa.fa-trash-o.deleted-user-avatar')
+      return iconNode('far-trash-alt', { class: 'deleted-user-avatar'} )
     }
   },
 

--- a/assets/javascripts/discourse/widgets/templates/babble-post.js.es6
+++ b/assets/javascripts/discourse/widgets/templates/babble-post.js.es6
@@ -67,7 +67,7 @@ export default Ember.Object.create({
     } else if (this.post.user_id) {
       return avatarImg('medium', {template: this.post.avatar_template, username: this.post.username})
     } else {
-      return iconNode('far-trash-alt', { class: 'deleted-user-avatar'} )
+      return iconNode('trash-o', { class: 'deleted-user-avatar'} )
     }
   },
 

--- a/assets/stylesheets/babble.scss
+++ b/assets/stylesheets/babble.scss
@@ -68,7 +68,7 @@ $default-chat-width: 300px;
   padding: 0;
   bottom: 40px;
   background: $primary !important;
-  .d-icon { color: $secondary !important; }
+  .fa { color: $secondary !important; }
   &--left {
     left: -10px;
     border-radius: 0 100px 100px 0;
@@ -99,7 +99,7 @@ $default-chat-width: 300px;
     height: 0px !important;
     opacity: 0;
     bottom: 100%;
-    .babble-unread, .d-icon { display: none; }
+    .babble-unread, .fa { display: none; }
     pointer-events: none;
     border-radius: 0;
   }
@@ -257,7 +257,7 @@ $default-chat-width: 300px;
     justify-content: space-between;
   }
 
-  .babble-post-actions-ellipsis .d-icon {
+  .babble-post-actions-ellipsis .fa {
     margin: 5px 0 0 0 !important;
   }
 

--- a/assets/stylesheets/babble.scss
+++ b/assets/stylesheets/babble.scss
@@ -68,20 +68,26 @@ $default-chat-width: 300px;
   padding: 0;
   bottom: 40px;
   background: $primary !important;
-  i { color: $secondary !important; }
+  .d-icon { color: $secondary !important; }
   &--left {
     left: -10px;
     border-radius: 0 100px 100px 0;
+    .widget-button {
+      border-radius: 0 100px 100px 0;
+    }
     .babble-unread--sidebar { right: 0; }
   }
   &--right {
     right: -10px;
     border-radius: 100px 0 0 100px;
+    .widget-button {
+      border-radius: 100px 0 0 100px;
+    }
     .babble-unread--sidebar { left: 0; }
   }
   .widget-button {
     background: none;
-    padding: 15px;
+    padding: 20px;
   }
   .spinner {
     width: 15px;
@@ -93,7 +99,7 @@ $default-chat-width: 300px;
     height: 0px !important;
     opacity: 0;
     bottom: 100%;
-    .babble-unread, i { display: none; }
+    .babble-unread, .d-icon { display: none; }
     pointer-events: none;
     border-radius: 0;
   }
@@ -251,7 +257,7 @@ $default-chat-width: 300px;
     justify-content: space-between;
   }
 
-  .babble-post-actions-ellipsis i {
+  .babble-post-actions-ellipsis .d-icon {
     margin: 5px 0 0 0 !important;
   }
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -4,7 +4,7 @@ en:
   site_settings:
     babble_enabled: "Enable Babble Shoutbox plugin."
     babble_placeholder: "Leave blank for default placeholder text in empty chat textarea. Or enter your custom text here."
-    babble_icon: "Font Awesome code (fa- omitted) for the Babble icon in the upper right corner. See http://fontawesome.io/cheatsheet/ for a list of icons."
+    babble_icon: "Font Awesome code (fa- omitted) for the Babble icon in the upper right corner. See http://fontawesome.io/cheatsheet/ for a list of icons. You might have to add the icon to the \"svg icon subset\" site setting as well."
     babble_category_name: "Discourse category for Babble topics."
     babble_remote_post: "Enable remote POST on message."
     babble_remote_url: "POST URL"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -4,7 +4,7 @@ en:
   site_settings:
     babble_enabled: "Enable Babble Shoutbox plugin."
     babble_placeholder: "Leave blank for default placeholder text in empty chat textarea. Or enter your custom text here."
-    babble_icon: "Font Awesome code (fa- omitted) for the Babble icon in the upper right corner. See http://fontawesome.io/cheatsheet/ for a list of icons. You might have to add the icon to the \"svg icon subset\" site setting as well."
+    babble_icon: "Font Awesome code (fa- omitted) for the Babble icon in the upper right corner."
     babble_category_name: "Discourse category for Babble topics."
     babble_remote_post: "Enable remote POST on message."
     babble_remote_url: "POST URL"

--- a/plugin.rb
+++ b/plugin.rb
@@ -7,6 +7,12 @@
 register_asset "stylesheets/babble.scss"
 enabled_site_setting :babble_enabled
 
+if respond_to?(:register_svg_icon)
+  register_svg_icon "bullhorn"
+  register_svg_icon "paperclip"
+  register_svg_icon "far-trash-alt"
+end
+
 def babble_require(path)
   require Rails.root.join('plugins', 'babble', 'app', path).to_s
 end


### PR DESCRIPTION
In the upcoming Discourse release, FontAwesome 4.7 font icons will be replaced by FA5 and SVGs. This PRs makes this plugin compatible with these changes in Discourse core. (I will write a guide on Meta shortly and update this PR's description with a link.) 