### PR TITLE
Fix ArgumentError Exception in Discourse 2.3.0.beta4

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,6 +1,6 @@
 class ::Group
   @@visible_group_scope = method(:visible_groups).clone
-  scope :visible_groups, ->(user, order = nil) {
-    @@visible_group_scope.call(user, order).where.not(visibility_level: 4)
+  scope :visible_groups, ->(user, order = nil, opts = nil) {
+    @@visible_group_scope.call(user, order, opts).where.not(visibility_level: 4)
   }
 end


### PR DESCRIPTION
@gdpelican This basically fixes the exception which disables search auto-complete functionality in 2.3.0.beta4. The related discourse change is https://github.com/discourse/discourse/commit/f8b70f4ca3f17efde7f8d5e626f692ab0f16e92e.

The exception is:
```
ArgumentError (wrong number of arguments (given 3, expected 1..2))
/var/www/discourse/plugins/babble/app/models/group.rb:3:in `block in <class:Group>'
```