### PR TITLE
FIX: Use top-level namespace for base classes

### DIFF
--- a/app/jobs/regular/babble_post_alert.rb
+++ b/app/jobs/regular/babble_post_alert.rb
@@ -1,5 +1,5 @@
 module Jobs
-  class BabblePostAlert < Jobs::Base
+  class BabblePostAlert < ::Jobs::Base
     def execute(args)
       return unless post = Post.find_by(id: args[:post_id])
       return unless post.topic&.archetype == Archetype.chat

--- a/app/jobs/scheduled/babble_prune_history.rb
+++ b/app/jobs/scheduled/babble_prune_history.rb
@@ -1,5 +1,5 @@
 module Jobs
-  class BabblePruneHistory < Jobs::Scheduled
+  class BabblePruneHistory < ::Jobs::Scheduled
     every 1.days
 
     def execute(args)


### PR DESCRIPTION
Fix similar to that one: https://github.com/discourse/discourse-assign/commit/d59e7fe1fbe95789324010b3729d0589a8a9789f

This is necessary since Discourse moved to Zeitwerk autoloader