### PR TITLE
Fix issue with search controller

### DIFF
--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -1,6 +1,6 @@
 class Search
   module FilterChats
-    def execute
+    def execute(**args)
       super.tap { @results.posts.reject! { |p| p.archetype == Archetype.chat } }
     end
   end


### PR DESCRIPTION
An extra parameter is passed in the search method in one of the latest updates 
https://github.com/discourse/discourse/blame/1972364d0f1b7907e726a8fce5a21a2d57f84b18/app/controllers/search_controller.rb#L132

I added a catch-all args to prevent it from getting busted by changes in the future. Tested and working.